### PR TITLE
Fixed the Items control issue

### DIFF
--- a/ePubReader/ePubReader/Controls/EPubItemContainer.xaml
+++ b/ePubReader/ePubReader/Controls/EPubItemContainer.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl x:Class="ePubReader.Controls.EPubItemContainer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:ePubReader.Controls"
+             xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="using:CompositionProToolkit.Controls"
+             xmlns:converters="using:ePubReader.Converters"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <converters:RasToImageSourceConverter x:Key="RasToImageSourceConverter" />
+    </UserControl.Resources>
+    <Interactivity:Interaction.Behaviors>
+        <controls:FluidPointerDragBehavior DragButton="MouseLeftButton" />
+    </Interactivity:Interaction.Behaviors>
+    <Grid Height="204"
+          Width="132"
+          Background="Transparent"
+          RightTapped="ePubItemRightTapped">
+        <Image Source="{Binding CoverStream, Converter={StaticResource RasToImageSourceConverter}, Mode=OneWay}"
+               Stretch="UniformToFill" />
+    </Grid>
+</UserControl>

--- a/ePubReader/ePubReader/Controls/EPubItemContainer.xaml.cs
+++ b/ePubReader/ePubReader/Controls/EPubItemContainer.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using ePubReader.Views;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace ePubReader.Controls
+{
+    public sealed partial class EPubItemContainer : UserControl
+    {
+        public EPubItemContainer()
+        {
+            this.InitializeComponent();
+        }
+        private void ePubItemRightTapped(object sender, RightTappedRoutedEventArgs e)
+        {
+            FrameworkElement ancestor = sender as FrameworkElement;
+
+            while (ancestor != null)
+            {
+                if (ancestor is MainPage)
+                {
+                    (ancestor as MainPage).HandleRightTap(sender, e);
+                    break;
+                }
+
+                ancestor = VisualTreeHelper.GetParent(ancestor) as FrameworkElement;
+            }
+        }
+    }
+}

--- a/ePubReader/ePubReader/Controls/EPubItemsControl.cs
+++ b/ePubReader/ePubReader/Controls/EPubItemsControl.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace ePubReader.Controls
+{
+    /// <summary>
+    /// Items control class to display EPubContainer items
+    /// </summary>
+    public class EPubItemsControl : ItemsControl
+    {
+        protected override DependencyObject GetContainerForItemOverride()
+        {
+            return new EPubItemContainer();
+        }
+
+        protected override bool IsItemItsOwnContainerOverride(object item)
+        {
+            return item is EPubItemContainer;
+        }
+    }
+}

--- a/ePubReader/ePubReader/Views/MainPage.xaml
+++ b/ePubReader/ePubReader/Views/MainPage.xaml
@@ -12,7 +12,7 @@
       xmlns:comppro="using:CompositionProToolkit.Controls"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:vm="using:ePubReader.ViewModels"
-      xmlns:controls1="using:ePubReader.Controls"
+      xmlns:localControls="using:ePubReader.Controls"
       mc:Ignorable="d"
       NavigationCacheMode="Enabled">
 
@@ -40,24 +40,30 @@
             </controls:PageHeader.PrimaryCommands>
         </controls:PageHeader>
 
-        <controls1:EPubItemsControl Grid.Row="1"
+        <localControls:EPubItemsControl Grid.Row="1"
                   ItemsSource="{Binding ImportedEPubs, Mode=TwoWay}"
                   Margin="12"
                   x:Name="ePubGridView">
-            <controls1:EPubItemsControl.ItemsPanel>
+            <localControls:EPubItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <comppro:FluidWrapPanel IsComposing="True"
                                             ItemHeight="204"
                                             ItemWidth="144"/>
                 </ItemsPanelTemplate>
-            </controls1:EPubItemsControl.ItemsPanel>
+            </localControls:EPubItemsControl.ItemsPanel>
             <FlyoutBase.AttachedFlyout>
                 <MenuFlyout x:Name="ePubMenuFlyout">
                     <MenuFlyoutItem Text="Change cover"
                                     Click="{x:Bind ViewModel.ChangeCoverMenuItemClick}"/>
                 </MenuFlyout>
             </FlyoutBase.AttachedFlyout>
-        </controls1:EPubItemsControl>
+        </localControls:EPubItemsControl>
     </Grid>
 </Page>
+
+
+
+
+
+
 

--- a/ePubReader/ePubReader/Views/MainPage.xaml
+++ b/ePubReader/ePubReader/Views/MainPage.xaml
@@ -11,7 +11,9 @@
       xmlns:local="using:ePubReader.Views"
       xmlns:comppro="using:CompositionProToolkit.Controls"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:vm="using:ePubReader.ViewModels" mc:Ignorable="d"
+      xmlns:vm="using:ePubReader.ViewModels"
+      xmlns:controls1="using:ePubReader.Controls"
+      mc:Ignorable="d"
       NavigationCacheMode="Enabled">
 
     <Page.Resources>
@@ -38,38 +40,24 @@
             </controls:PageHeader.PrimaryCommands>
         </controls:PageHeader>
 
-        <ItemsControl Grid.Row="1"
+        <controls1:EPubItemsControl Grid.Row="1"
                   ItemsSource="{Binding ImportedEPubs, Mode=TwoWay}"
                   Margin="12"
                   x:Name="ePubGridView">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate x:DataType="models:ePub">
-                    <Grid Height="204"
-                          Width="132"
-                          Background="Transparent"
-                          RightTapped="ePubItemRightTapped">
-                        <Interactivity:Interaction.Behaviors>
-                            <comppro:FluidPointerDragBehavior DragButton="MouseLeftButton"/>
-                        </Interactivity:Interaction.Behaviors>
-                        <Image Source="{x:Bind CoverStream, Converter={StaticResource RasToImageSourceConverter}, Mode=OneWay}"
-                               Stretch="UniformToFill"/>
-                    </Grid>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-            <ItemsControl.ItemsPanel>
+            <controls1:EPubItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <comppro:FluidWrapPanel IsComposing="True"
                                             ItemHeight="204"
                                             ItemWidth="144"/>
                 </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
+            </controls1:EPubItemsControl.ItemsPanel>
             <FlyoutBase.AttachedFlyout>
                 <MenuFlyout x:Name="ePubMenuFlyout">
                     <MenuFlyoutItem Text="Change cover"
                                     Click="{x:Bind ViewModel.ChangeCoverMenuItemClick}"/>
                 </MenuFlyout>
             </FlyoutBase.AttachedFlyout>
-        </ItemsControl>
+        </controls1:EPubItemsControl>
     </Grid>
 </Page>
 

--- a/ePubReader/ePubReader/Views/MainPage.xaml.cs
+++ b/ePubReader/ePubReader/Views/MainPage.xaml.cs
@@ -9,8 +9,9 @@ namespace ePubReader.Views
         {
             InitializeComponent();
         }
-
-        private void ePubItemRightTapped(object sender, RightTappedRoutedEventArgs e) =>
+        public void HandleRightTap(object sender, RightTappedRoutedEventArgs e)
+        {
             ePubMenuFlyout.ShowAt(ePubGridView);
+        }
     }
 }

--- a/ePubReader/ePubReader/ePubReader.csproj
+++ b/ePubReader/ePubReader/ePubReader.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>ePubReader</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.14388.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -99,6 +99,10 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controllers\ImportController.cs" />
+    <Compile Include="Controls\EPubItemContainer.xaml.cs">
+      <DependentUpon>EPubItemContainer.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Controls\EPubItemsControl.cs" />
     <Compile Include="Converters\RasToImageSourceConverter.cs" />
     <Compile Include="Models\ePub.cs" />
     <Compile Include="Models\ManifestItem.cs" />
@@ -146,6 +150,10 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Controls\EPubItemContainer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Styles\Custom.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -168,9 +176,7 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Controls\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\GitHub\CompositionProToolkit\CompositionProToolkit\CompositionProToolkit.csproj">
       <Project>{9300e54c-338c-4ad7-baac-bcbd32a660cf}</Project>


### PR DESCRIPTION
I have fixed the issue you faced (exception raised when dragging of items in the FluidWrapPanel).
### Root Cause

The default **ItemsControl** generates containers of type **ContentPresenter** which is added to the **FluidWrapPanel** as its children. In the **MainPage.xaml** file, you were adding the **FluidDragBehavior** to the **Grid** in the **DataTemplate**. As a result the item raising the drag event (**Grid** in this case) does not match with the child (which is of type **ContentPresenter**) in the **FluidWrapPanel**. Therefore exception is raised.
### Solution

I have added a class called **EPubItemContainer** which will host the content that you defined in the **DataTemplate** of the **ItemsControl** (in **MainPage.xaml**). This class will be raising the drag event.
I have also added a class **EPubItemsControl** which derives from **ItemsControl** and overrides the following methods to specify that that generated container will be of type **EPubItemContainer**

``` C#
protected override DependencyObject GetContainerForItemOverride()
{
    return new EPubItemContainer();
}

protected override bool IsItemItsOwnContainerOverride(object item)
{
    return item is EPubItemContainer;
}
```

With these changes, the children being tracked in the **FluidWrapPanel** and the objects raising the drag event are of same type (**EPubItemContainer**).
